### PR TITLE
fix transalte scheme

### DIFF
--- a/ai.text.translate.openapi.json
+++ b/ai.text.translate.openapi.json
@@ -81,7 +81,7 @@
                         "in": "query",
                         "name": "billing",
                         "required": false,
-                        "description": "Billing avaliable via Intento",
+                        "description": "Billing available via Intento",
                         "schema": {
                             "type": "boolean"
                         }
@@ -400,7 +400,7 @@
     "components": {
         "securitySchemes": {
             "APIKeyHeader": {
-                "type": "apiKey",
+                "type": "string",
                 "in": "header",
                 "name": "apikey"
             }
@@ -428,15 +428,15 @@
                         "properties": {
                             "text": {
                                 "description": "Text to translate",
-                                "allOf": [
+                                "anyOf": [
                                     {
                                         "type": "string"
                                     },
                                     {
+                                        "type": "array",
                                         "items": {
                                             "type": "string"
-                                        },
-                                        "type": "array"
+                                        }
                                     }
                                 ]
                             },
@@ -463,11 +463,7 @@
                             },
                             "category": {
                                 "description": "Translation domain",
-                                "type": "string",
-                                "enum": [
-                                    "general"
-                                ],
-                                "default": "auto"
+                                "type": "string"
                             }
                         }
                     },
@@ -479,8 +475,8 @@
                                 "description": "Provider identificator to use for the request. A list of the available providers is returned by the GET request. If not specified, the provider is selected according to the bidding policy",
                                 "type": "string"
                             },
-                            "bidding": {
-                                "description": "Policy to select the provider if it is not specified. The default value is 'auto'",
+                            "routing": {
+                                "description": "Policy to select the provider if it is not specified. The default value is 'best'",
                                 "type": "string",
                                 "enum": [
                                     "best",
@@ -528,17 +524,10 @@
                 "properties": {
                     "results": {
                         "description": "Translated text",
-                        "allOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        ]
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "service": {
                         "description": "Service information regarding the intent fulfillment",


### PR DESCRIPTION
Fixes:
- `results` type in response
- typo in billing description
- apikey type
- `context.text` type
- rename `bidding` to `routing`
- fix `context.category` type